### PR TITLE
POSTFIX not requiring SMTP credentials & .env example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+ENV=<your-terraform-namespace>
+CODEBUILD_BUILD_NUMBER=786
+AWS_VAULT_PROFILE=<your-shared-services-aws-vault-profile-name>
+SHARED_SERVICES_ACCOUNT_ID=<shared-services-account-id>
+REGISTRY_URL=<development-aws-account-id>.dkr.ecr.eu-west-2.amazonaws.com
+
+RELAY_DOMAIN=<devl-office-365-domain>
+RELAY_SMART_HOST=<devl-office-365-MX-endpoint>
+
+TEST_EMAIL_ADDRESS=<any-email-address-in-devl-domain>
+MAILBOX_FOR_TEST_EMAIL=<any-mailbox-to-recieve-test-email>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,13 @@ services:
             args: 
                 SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
         environment:
-            POSTFIX_HOSTNAME: "${POSTFIX_HOSTNAME}"
-            POSTFIX_RELAY_HOST: "${POSTFIX_RELAY_HOST}"
-            POSTFIX_RELAY_USER: "${POSTFIX_RELAY_USER}"
-            POSTFIX_RELAY_PASSWORD: "${POSTFIX_RELAY_PASSWORD}"
+            RELAY_DOMAIN: "${RELAY_DOMAIN}"
+            RELAY_SMART_HOST: "${RELAY_SMART_HOST}"
     smtp_relay_test:
         build:
             context: ./smtp-relay-test
             args: 
                 SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
+        environment:
+            TEST_EMAIL_ADDRESS: "${TEST_EMAIL_ADDRESS}"
+            MAILBOX_FOR_TEST_EMAIL: "${MAILBOX_FOR_TEST_EMAIL}"

--- a/smtp-relay-test/test.sh
+++ b/smtp-relay-test/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-echo "This is a Test Email from SMTP Relay Server" | mail -s "Test email from SMTP Relays Server" -S mta=smtp://smtp_relay_server:587 -Ssmtp-auth=none postfix-test-user@devl.justice.gov.uk
+echo "This is a Test Email from SMTP Relay Server" | mail -s "Test email from SMTP Relays Server" -S mta=smtp://smtp_relay_server:587 -S from=$TEST_EMAIL_ADDRESS -S smtp-auth=none $MAILBOX_FOR_TEST_EMAIL
 
 exec "$@"


### PR DESCRIPTION
POSTFIX does not need credentials against Office 365 Smart Host,
therefore removing unnecessary environment variables from Dockerfile,
Updates in smtp-relay-test script.
Includes .env.example file