### PR TITLE
Expose SMTP Port 25 on Postfix Docker Image

### DIFF
--- a/smtp-relay-test/Dockerfile
+++ b/smtp-relay-test/Dockerfile
@@ -5,6 +5,6 @@ RUN apk add --no-cache --update s-nail
 
 COPY test.sh /usr/local/bin/
 
-EXPOSE 587
+EXPOSE 587 25
 
 CMD ["sh", "/usr/local/bin/test.sh"]

--- a/smtp-relay/Dockerfile
+++ b/smtp-relay/Dockerfile
@@ -10,7 +10,7 @@ VOLUME [ "/var/spool/postfix", "/etc/postfix" ]
 
 COPY entrypoint.sh /usr/local/bin/
 
-EXPOSE 587
+EXPOSE 587 25
 
 ENTRYPOINT ["entrypoint.sh"]
 


### PR DESCRIPTION
Expose SMTP Port 25 on Docker Image to allow unconfigurable devices access to the SMTP Relay service.