### PR TITLE
:wrench: create-codeowners-file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/cloud-ops-admins


### PR DESCRIPTION
Create CODEOWNERS file containing 'cloud-ops-admins' team to improve GibHub branch protection rules.