### PR TITLE
use newer postfix_exporter

### DIFF
--- a/smtp-relay-monitoring/Dockerfile
+++ b/smtp-relay-monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM unikum/postfix_exporter:latest
+FROM ghcr.io/hsn723/postfix_exporter:0.5.2
 
 VOLUME [ "/var/log/mail", "/var/spool/postfix" ]
 


### PR DESCRIPTION
Use newer postfix exporter to resolve CVE

![image](https://github.com/ministryofjustice/staff-infrastructure-smtp-relay-server/assets/144033531/74743d46-7203-4896-aa79-87ebf136181b)


This is a test, if we see dedication in the logs, we will roll this back and try a different approach. 