### PR TITLE
Revert "use newer postfix_exporter"

### DIFF
--- a/smtp-relay-monitoring/Dockerfile
+++ b/smtp-relay-monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hsn723/postfix_exporter:0.5.2
+FROM unikum/postfix_exporter:latest
 
 VOLUME [ "/var/log/mail", "/var/spool/postfix" ]
 


### PR DESCRIPTION
Reverts ministryofjustice/staff-infrastructure-smtp-relay-server#88

The container does not seem to support flags with the newer base image scratch "https://github.com/Hsn723/postfix_exporter/issues/61"